### PR TITLE
Add overflow menu for cards in kanban view

### DIFF
--- a/src/pages/Dashboard/components/Kanban.js
+++ b/src/pages/Dashboard/components/Kanban.js
@@ -16,12 +16,15 @@ import {
   Grid,
   IconButton,
   Typography,
+  Menu,
+  MenuItem
 } from '@mui/material';
 import {
   AddRounded,
   EditRounded,
   DeleteRounded,
   TrendingFlatRounded,
+  MoreHoriz as MoreHorizIcon,
 } from '@mui/icons-material';
 
 const useStyles = makeStyles((theme) => ({
@@ -66,6 +69,8 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+const ITEM_HEIGHT = 48;
+
 const Kanban = ({
   statuses,
   product,
@@ -78,6 +83,16 @@ const Kanban = ({
 }) => {
   const classes = useStyles();
   const [columns, setColumns] = useState({});
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
 
   useEffect(() => {
     let cols = {};
@@ -194,13 +209,18 @@ const Kanban = ({
                         ref={provided.innerRef}
                       >
                         {_.map(column.items, (item, itemIndex) => (
-                          <Draggable
-                            key={item.issue_uuid
-                              ? item.issue_uuid
-                              : item.feature_uuid}
-                            draggableId={item.issue_uuid
-                              ? item.issue_uuid
-                              : item.feature_uuid}
+
+                          < Draggable
+                            key={
+                              item.issue_uuid
+                                ? item.issue_uuid
+                                : item.feature_uuid
+                            }
+                            draggableId={
+                              item.issue_uuid
+                                ? item.issue_uuid
+                                : item.feature_uuid
+                            }
                             index={itemIndex}
                           >
                             {(provided, snapshot) => (
@@ -240,7 +260,7 @@ const Kanban = ({
                                         aria-controls="menu-card"
                                         aria-haspopup="false"
                                         color="secondary"
-                                        onClick={(e) => editItem(item, item.featureUUID ? 'issue' : 'feat')}
+                                        onClick={(e) => editItem(item, item.issue_uuid ? 'issue' : 'feat')}
                                         size="large"
                                         className={classes.iconButton}
                                       >
@@ -251,12 +271,49 @@ const Kanban = ({
                                         aria-controls="menu-card"
                                         aria-haspopup="false"
                                         color="secondary"
-                                        onClick={(e) => deleteItem(item, item.featureUUID ? 'issue' : 'feat')}
+                                        onClick={(e) => deleteItem(item, item.issue_uuid ? 'issue' : 'feat')}
                                         size="large"
                                         className={classes.iconButton}
                                       >
                                         <DeleteRounded fontSize="small" />
                                       </IconButton>
+                                      <IconButton
+                                        id="menu-button"
+                                        aria-label="column-options"
+                                        aria-controls="menu-column"
+                                        aria-haspopup="true"
+                                        color="secondary"
+                                        aria-controls={open ? 'menu-column' : undefined}
+                                        aria-expanded={open ? 'true' : undefined}
+                                        onClick={handleClick}
+
+                                      >
+                                        <MoreHorizIcon />
+                                      </IconButton>
+                                      <Menu
+                                        id="long-menu"
+                                        MenuListProps={{
+                                          'aria-labelledby': 'long-button',
+                                        }}
+                                        anchorEl={anchorEl}
+                                        open={open}
+
+                                        PaperProps={{
+                                          style: {
+                                            maxHeight: ITEM_HEIGHT * 4.5,
+                                            width: '20ch',
+                                          },
+                                        }}
+
+                                      >
+                                        <MenuItem selected key={itemIndex} onClick={() => { editItem(item, item.issue_uuid ? 'issue' : 'feat'), handleClose() }}>
+                                          Edit
+                                        </MenuItem>
+                                        <MenuItem onClick={() => { deleteItem(item, item.issue_uuid ? 'issue' : 'feat'), handleClose() }}>
+                                          Delete
+                                        </MenuItem>
+
+                                      </Menu>
                                     </div>
                                   )}
                                 />
@@ -292,7 +349,7 @@ const Kanban = ({
               </Grid>
             ))}
           </Grid>
-        </DragDropContext>
+        </DragDropContext >
       )}
     </>
   );

--- a/src/pages/Dashboard/components/Kanban.js
+++ b/src/pages/Dashboard/components/Kanban.js
@@ -17,7 +17,7 @@ import {
   IconButton,
   Typography,
   Menu,
-  MenuItem
+  MenuItem,
 } from '@mui/material';
 import {
   AddRounded,
@@ -214,7 +214,7 @@ const Kanban = ({
                         ref={provided.innerRef}
                       >
                         {_.map(column.items, (item, itemIndex) => (
-                          < Draggable
+                          <Draggable
                             key={
                               item.issue_uuid
                                 ? item.issue_uuid
@@ -265,8 +265,7 @@ const Kanban = ({
                                         aria-controls="menu-column"
                                         aria-haspopup="true"
                                         color="secondary"
-                                        aria-controls={open ? 'menu-column' : undefined}
-                                        aria-expanded={open ? 'true' : undefined}
+                                        aria-expanded
                                         onClick={(e) => handleClick(e, item)}
 
                                       >
@@ -278,7 +277,6 @@ const Kanban = ({
                                           'aria-labelledby': 'long-button',
                                         }}
                                         anchorEl={anchorEl}
-                                        open={open}
                                         open={currentNumber === item}
                                         PaperProps={{
                                           style: {
@@ -289,10 +287,18 @@ const Kanban = ({
                                         onClick={handleClose}
                                       >
                                         {_.map(options, (option, optInd) => (
-                                          <MenuItem key={optInd} selected={option === 'Edit'} onClick={(e) => {
-                                            option == 'Edit' ? editItem(item, item.issue_uuid ? 'issue' : 'feat')
-                                              : deleteItem(item, item.issue_uuid ? 'issue' : 'feat')
-                                          }}>
+                                          <MenuItem
+                                            key={optInd}
+                                            selected={option === 'Edit'}
+                                            onClick={(e) => {
+                                              const type = item.issue_uuid ? 'issue' : 'feat';
+                                              if (option === 'Edit') {
+                                                editItem(item, type);
+                                              } else {
+                                                deleteItem(item, type);
+                                              }
+                                            }}
+                                          >
                                             {option}
                                           </MenuItem>
                                         ))}
@@ -332,7 +338,7 @@ const Kanban = ({
               </Grid>
             ))}
           </Grid>
-        </DragDropContext >
+        </DragDropContext>
       )}
     </>
   );

--- a/src/pages/Dashboard/components/Kanban.js
+++ b/src/pages/Dashboard/components/Kanban.js
@@ -24,7 +24,7 @@ import {
   EditRounded,
   DeleteRounded,
   TrendingFlatRounded,
-  MoreHoriz as MoreHorizIcon,
+  MoreHoriz,
 } from '@mui/icons-material';
 
 const useStyles = makeStyles((theme) => ({
@@ -69,7 +69,10 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const ITEM_HEIGHT = 48;
+const options = [
+  'Edit',
+  'Delete',
+];
 
 const Kanban = ({
   statuses,
@@ -84,15 +87,17 @@ const Kanban = ({
   const classes = useStyles();
   const [columns, setColumns] = useState({});
   const [anchorEl, setAnchorEl] = React.useState(null);
+  const [currentNumber, setCurrentNumber] = React.useState(null);
   const open = Boolean(anchorEl);
 
-  const handleClick = (event) => {
+  const handleClick = (event, number) => {
     setAnchorEl(event.currentTarget);
+    setCurrentNumber(number);
   };
   const handleClose = () => {
     setAnchorEl(null);
+    setCurrentNumber(null);
   };
-
 
   useEffect(() => {
     let cols = {};
@@ -209,7 +214,6 @@ const Kanban = ({
                         ref={provided.innerRef}
                       >
                         {_.map(column.items, (item, itemIndex) => (
-
                           < Draggable
                             key={
                               item.issue_uuid
@@ -256,28 +260,6 @@ const Kanban = ({
                                         </IconButton>
                                       )}
                                       <IconButton
-                                        aria-label="edit-ticket"
-                                        aria-controls="menu-card"
-                                        aria-haspopup="false"
-                                        color="secondary"
-                                        onClick={(e) => editItem(item, item.issue_uuid ? 'issue' : 'feat')}
-                                        size="large"
-                                        className={classes.iconButton}
-                                      >
-                                        <EditRounded fontSize="small" />
-                                      </IconButton>
-                                      <IconButton
-                                        aria-label="delete-ticket"
-                                        aria-controls="menu-card"
-                                        aria-haspopup="false"
-                                        color="secondary"
-                                        onClick={(e) => deleteItem(item, item.issue_uuid ? 'issue' : 'feat')}
-                                        size="large"
-                                        className={classes.iconButton}
-                                      >
-                                        <DeleteRounded fontSize="small" />
-                                      </IconButton>
-                                      <IconButton
                                         id="menu-button"
                                         aria-label="column-options"
                                         aria-controls="menu-column"
@@ -285,10 +267,10 @@ const Kanban = ({
                                         color="secondary"
                                         aria-controls={open ? 'menu-column' : undefined}
                                         aria-expanded={open ? 'true' : undefined}
-                                        onClick={handleClick}
+                                        onClick={(e) => handleClick(e, item)}
 
                                       >
-                                        <MoreHorizIcon />
+                                        <MoreHoriz />
                                       </IconButton>
                                       <Menu
                                         id="long-menu"
@@ -297,22 +279,23 @@ const Kanban = ({
                                         }}
                                         anchorEl={anchorEl}
                                         open={open}
-
+                                        open={currentNumber === item}
                                         PaperProps={{
                                           style: {
-                                            maxHeight: ITEM_HEIGHT * 4.5,
+                                            maxHeight: 48 * 4.5,
                                             width: '20ch',
                                           },
                                         }}
-
+                                        onClick={handleClose}
                                       >
-                                        <MenuItem selected key={itemIndex} onClick={() => { editItem(item, item.issue_uuid ? 'issue' : 'feat'), handleClose() }}>
-                                          Edit
-                                        </MenuItem>
-                                        <MenuItem onClick={() => { deleteItem(item, item.issue_uuid ? 'issue' : 'feat'), handleClose() }}>
-                                          Delete
-                                        </MenuItem>
-
+                                        {_.map(options, (option, optInd) => (
+                                          <MenuItem key={optInd} selected={option === 'Edit'} onClick={(e) => {
+                                            option == 'Edit' ? editItem(item, item.issue_uuid ? 'issue' : 'feat')
+                                              : deleteItem(item, item.issue_uuid ? 'issue' : 'feat')
+                                          }}>
+                                            {option}
+                                          </MenuItem>
+                                        ))}
                                       </Menu>
                                     </div>
                                   )}


### PR DESCRIPTION
## Purpose
_Add overflow menu for cards in kanban view_

## Further info
_Move edit and delete options into overflow menu_

## Ticket number
#35 
